### PR TITLE
Cli/Ember update / CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-sudo: required  
+sudo: required
 dist: trusty
 language: node_js
 node_js:
@@ -24,7 +24,7 @@ before_install:
   - npm install phantomjs-prebuilt
   - node_modules/phantomjs-prebuilt/bin/phantomjs --version
   - export CHROME_BIN=/usr/bin/google-chrome
-  - export DISPLAY=:99.0 
+  - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sudo apt-get update
   - sudo apt-get install -y libappindicator1 fonts-liberation

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "4"
+  - "7"
 
 cache:
   directories:

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,14 @@
 {
   "name": "ember-shell",
   "dependencies": {
-    "ember": "canary",
-    "ember-cli-shims": "0.1.3",
     "mocha": "~2.2.4",
     "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1",
-    "url.js": "jillix/url.js#^2.4.0",
-    "animation-frame": "^0.2.4"
+    "animation-frame": "^0.2.4",
+    "ember-cli-shims": "^0.1.3",
+    "url.js": "jillix/url.js#^2.4.0"
   },
   "devDependencies": {
     "url.js": "jillix/url.js#^2.4.0"
-  },
-  "resolutions": {
-    "ember": "canary"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -10,6 +10,11 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     }
   ]

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 'use strict';
 
-module.exports = function(/*environment*/) {
-
+module.exports = function(/* environment, appConfig */) {
+  return { };
 };

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const Funnel = require('broccoli-funnel');
+const existsSync = require('exists-sync');
 const mergeTrees = require('ember-cli/lib/broccoli/merge-trees');
 const broccoliPostcss = require('broccoli-postcss');
 const { preprocessTemplates} = require('ember-cli-preprocess-registry/preprocessors');
@@ -40,6 +41,9 @@ module.exports = {
 
     packages.forEach( pkg => {
       const pkgApp = path.join(this.packagesPath, pkg.name, 'app');
+      if (!existsSync(pkgApp)) {
+        return;
+      }
       addonApp.push(new WatchedDir(pkgApp));
     });
 
@@ -63,6 +67,10 @@ module.exports = {
     packages.forEach(pkg => {
       const pkgLib = path.join(this.packagesPath, pkg.name, 'lib');
       const pkgTemplates = path.join(pkgLib, 'templates');
+
+      if (!existsSync(pkgLib)) {
+        return;
+      }
 
       addonJS.push(new WatchedDir(pkgLib));
 
@@ -118,6 +126,9 @@ module.exports = {
 
     packages.forEach( pkg => {
       const pkgPublic = path.join(this.packagesPath, pkg.name, 'public');
+      if (!existsSync(pkgPublic)) {
+        return;
+      }
       addonPublic.push(new Funnel(pkgPublic, {
         destDir: '/'
       }));

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 const path = require('path');
 const Funnel = require('broccoli-funnel');
-const mergeTrees = require('broccoli-merge-trees');
+const mergeTrees = require('ember-cli/lib/broccoli/merge-trees');
 const broccoliPostcss = require('broccoli-postcss');
 const { preprocessTemplates} = require('ember-cli-preprocess-registry/preprocessors');
 const { WatchedDir } = require('broccoli-source');

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-sinon-chai": "0.1.1",
     "ember-source": "^2.11.0-beta.2",
     "ember-variable-styles": "^0.0.3",
+    "exists-sync": "0.0.4",
     "loader.js": "^4.0.10",
     "postcss-cssnext": "^2.8.0",
     "postcss-import": "^8.2.0"

--- a/package.json
+++ b/package.json
@@ -23,21 +23,16 @@
   "license": "MIT",
   "homepage": "http://ember-shell.com/",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
-    "broccoli-babel-transpiler": "^5.6.1",
     "broccoli-concat": "^3.0.5",
     "broccoli-funnel": "^1.0.9",
-    "broccoli-merge-trees": "^1.1.5",
     "broccoli-postcss": "^3.1.0",
     "chai": "^3.5.0",
     "cssnano": "^3.8.0",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "^2.10.0",
+    "ember-cli": "^2.11.0-beta.1",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-custom-assertions": "0.0.6",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-doc-server": "1.1.0",
-    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
@@ -50,19 +45,19 @@
     "ember-cli-yuidoc": "0.8.7",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
+    "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-run-raf": "git+https://github.com/runspired/ember-run-raf.git#4e9fa2859dd9eb2129ad6d72fac37ab65a4fc0cd",
     "ember-sinon-chai": "0.1.1",
+    "ember-source": "^2.11.0-beta.2",
     "ember-variable-styles": "^0.0.3",
     "loader.js": "^4.0.10",
     "postcss-cssnext": "^2.8.0",
-    "postcss-import": "^8.2.0",
-    "urljs": "2.3.1"
+    "postcss-import": "^8.2.0"
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "^1.0.10"
+    "ember-cli-htmlbars": "^1.1.1"
   },
   "keywords": [
     "ember-addon",

--- a/testem.js
+++ b/testem.js
@@ -1,6 +1,13 @@
 /*jshint node:true*/
 module.exports = {
-  "framework": "mocha",
-  "test_page": "tests/index.html?#hide_passed",
-  "disable_watching": true
+  "framework": "qunit",
+  "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
+  "launch_in_ci": [
+    "PhantomJS"
+  ],
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
+  ]
 };

--- a/testem.js
+++ b/testem.js
@@ -1,13 +1,16 @@
 /*jshint node:true*/
 module.exports = {
-  "framework": "qunit",
+  "framework": "mocha",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "PhantomJS",
+    "Chrome",
+    "Firefox"
   ],
   "launch_in_dev": [
     "PhantomJS",
-    "Chrome"
+    "Chrome",
+    "Firefox"
   ]
 };

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  // use defaults, but you can override
-  let attributes = Ember.assign({}, config.APP, attrs);
+  let attributes = Ember.merge({}, config.APP);
+  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
- Updated to latests ember-cli (2.11.0-beta.1)
- It now uses ember-source (2.11.0-beta.2)
- Fixed CI issues (use node 7 instead of 4)
- Fixed build not working due to tree missing folders